### PR TITLE
setup.py 내에 get_spec 함수 구현

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,20 @@
+import io
+import os
+
 from setuptools import setup
 
+
+def get_spec(filename, mode='r'):
+    def wrapper():
+        here = os.path.dirname(__file__)
+        result = {}
+        with io.open(os.path.join(here, filename), encoding='utf-8') as src_file:
+            result = src_file.read()
+        return result
+    return wrapper
+
+
+get_requirements = get_spec('requirements.txt')
 setup(
     name            = 'pyupbit',
     version         = '0.2.6',
@@ -7,7 +22,7 @@ setup(
     url             = 'https://github.com/sharebook-kr/pyupbit',
     author          = 'Lukas Yoo, Brayden Jo',
     author_email    = 'brayden.jo@outlook.com, jonghun.yoo@outlook.com, pystock@outlook.com',
-    install_requires= ['requests', 'pandas', 'pyjwt'],
+    install_requires= get_requirements(),
     license         = 'MIT',
     packages        = ['pyupbit'],
     zip_safe        = False


### PR DESCRIPTION
이 `get_spec` 함수를 이용함으로써, `requirements.txt`에 업데이트 된 사항들을 `setup.py`에 자동적으로 반영할 수 있습니다.

원래 구현되어있던 `setup.py`는 `requirements.txt`에 있는 사항들 전부 반영하지는 않아, `python setup.py install` 커맨드가 실패하는
현상이 존재했습니다 (e.g., `numpy` 패키지가 설치되지 않은 환경). 따라서, 이를 해결하기 위하여 `get_spec` 함수를 구현하였습니다.

또한, [예시](https://github.com/LUXROBO/pymodi/blob/master/setup.py) 와 같이, 이 함수를 `requirements.txt` 뿐만이 아니라 추후 `readme.md`, `history.md` 등의 파일에도 적용할 수 있을 것으로 생각됩니다.