### PR TITLE
get_current_price 함수를 통한 현재가 검색시 TypeError 나오는 에러 수정

### DIFF
--- a/pyupbit/quotation_api.py
+++ b/pyupbit/quotation_api.py
@@ -122,7 +122,7 @@ def get_current_price(ticker="KRW-BTC"):
                     ret[market] = price
                 return ret
             else:
-                return contents[0]['trade_price']
+                return contents[0][0]['trade_price']
         else:
             return None
     except Exception as x:

--- a/pyupbit/quotation_api.py
+++ b/pyupbit/quotation_api.py
@@ -110,24 +110,21 @@ def get_current_price(ticker="KRW-BTC"):
     """
     try:
         url = "https://api.upbit.com/v1/ticker"
-        contents = _call_public_api(url, markets=ticker)
-
-        if contents is not None:
-            # 여러 마케을 동시에 조회
-            if isinstance(ticker, list):
-                ret = {}
-                for content in contents:
-                    market = content['market']
-                    price = content['trade_price']
-                    ret[market] = price
-                return ret
-            else:
-                return contents[0][0]['trade_price']
-        else:
+        contents = _call_public_api(url, markets=ticker)[0]
+        if not contents:
             return None
+
+        if isinstance(ticker, list):
+            ret = {}
+            for content in contents:
+                market = content['market']
+                price = content['trade_price']
+                ret[market] = price
+            return ret
+        else:
+            return contents[0]['trade_price']
     except Exception as x:
         print(x.__class__.__name__)
-        return None
 
 
 def get_orderbook(tickers="KRW-BTC"):


### PR DESCRIPTION
[README](https://github.com/sharebook-kr/pyupbit#pyupbit)에 있는 예제를 따라하다, [최근 체결가격](https://github.com/sharebook-kr/pyupbit#%EC%B5%9C%EA%B7%BC-%EC%B2%B4%EA%B2%B0%EA%B0%80%EA%B2%A9) 부분에 있는 아래의 커맨드를 실행했을 때 [get_current_price](https://github.com/sharebook-kr/pyupbit/blob/master/pyupbit/quotation_api.py#L125) 함수에서 `TypeError`가 발생하는 오류를 발견하였습니다.

```python
# 단일 ticker 
>>> pyupbit.get_current_price("KRW-BTC")
TypeError

# 다중 ticker
>>> pyupbit.get_current_price(["KRW-BTC", "KRW-XRP"])
TypeError
```

내부 `contents` 오브젝트를 확인해보니 `contents`의 결괏값이 튜플로 한번, 리스트로 한번, 총 두번씩 쌓여있는것을 발견하였습니다.

이는 `contents` 값을 반환하는 [_call_public_api](https://github.com/sharebook-kr/pyupbit/blob/8c55f5d6802ce4639c6142520b83e80b79de447b/pyupbit/request_api.py#L46) 함수가 `contents` 뿐만이 아니라 `remaining_req_dict`도 추가적으로 반환하기 때문으로 보여집니다.

따라서 `[0]`를 한번 더 넣어서 `_call_public_api`에서 반환되는 튜플의 첫번째 요소를 인덱싱하여 `contents` 만을 가져옴으로써 위의 오류를 해결하였습니다.