### PR TITLE
get_orderbook 함수를 통한 orderbook 검색시 추가적으로 나오는 remaining_req_dict 정보 삭제

### DIFF
--- a/pyupbit/quotation_api.py
+++ b/pyupbit/quotation_api.py
@@ -138,7 +138,7 @@ def get_orderbook(tickers="KRW-BTC"):
     '''
     try:
         url = "https://api.upbit.com/v1/orderbook"
-        contents = _call_public_api(url, markets=tickers)
+        contents = _call_public_api(url, markets=tickers)[0]
         return contents
     except Exception as x:
         print(x.__class__.__name__)


### PR DESCRIPTION
[get_current_price 함수](https://github.com/sharebook-kr/pyupbit/pull/7)와 마찬가지로, [_call_public_api](https://github.com/sharebook-kr/pyupbit/blob/8c55f5d6802ce4639c6142520b83e80b79de447b/pyupbit/request_api.py#L46) 함수는 `contents`와 `remaining_req_dict`를 포함하는 튜플을 반환하므로 `contents`에 접근하려면 반환되는 튜플의 첫번째 원소에 접근이 필요한것으로 보입니다. 따라서 `[0]`을 통한 인덱싱으로 원하는 값인 `contents`에 접근할 수 있게 코드를 수정하였습니다.