### PR TITLE
fix(exchange_api): array of strings query 대응

### DIFF
--- a/pyupbit/exchange_api.py
+++ b/pyupbit/exchange_api.py
@@ -43,7 +43,7 @@ class Upbit:
 
         if query is not None:
             m = hashlib.sha512()
-            m.update(urlencode(query).encode())
+            m.update(urlencode(query, doseq=True).replace("%5B%5D=", "[]=").encode())
             query_hash = m.hexdigest()
             payload['query_hash'] = query_hash
             payload['query_hash_alg'] = "SHA512"


### PR DESCRIPTION
업비트의 '주문 리스트 조회' API는 다음과 같이 array of strings를 요청 파라미터로 받고 있습니다.

```
GET https://api.upbit.com/v1/orders/?uuids[]=xxxx&uuids[]=yyyy
```

Python의 `urllib.parse.urlencode`는 `doseq=True`가 아닌 경우, value로 array가 주어졌을 때 이를 그대로 encode합니다. 따라서 query string 규칙에 맞지 않는 요청값을 sign하여 에러가 나는 문제가 있어, 이를 수정하였습니다.

```python
from urllib.parse import urlencode

data = {"uuids[]": ["xxx", "yyy"]}
urlencode(data) # 'uuids%5B%5D=%5B%27xxx%27%2C+%27yyy%27%5D'
urlencode(data, doseq=True) # 'uuids%5B%5D=xxx&uuids%5B%5D=yyy'
urlencode(data, doseq=True).replace("%5B%5D=", "[]=") # 'uuids[]=xxx&uuids[]=yyy'


