### PR TITLE
Error 클래스 개선 및 request_api.py 상에 Linter를 위한 typing 추가

### DIFF
--- a/pyupbit/errors.py
+++ b/pyupbit/errors.py
@@ -1,112 +1,177 @@
-import json 
+from requests import Response
+from typing import Any
+
+__all__ = [
+    "CreateAskError",
+    "CreateBidError",
+    "InsufficientFundsAsk",
+    "InsufficientFundsBid",
+    "UnderMinTotalAsk",
+    "UnderMinTotalBid",
+    "WidthdrawAddressNotRegisterd",
+    "ValidationError",
+    "InvalidQueryPayload",
+    "JwtVerification",
+    "ExpiredAccessKey",
+    "NonceUsed",
+    "NoAutorizationIP",
+    "OutOfScope",
+    "TooManyRequests",
+    "RemainingReqParsingError",
+    "InValidAccessKey",
+    "raise_error",
+]
 
 
-class UpbitError(Exception):
-    def __str__(self):
-        return "Upbit Base Error"
+class UpbitErrorMixin:
+    name: str
+    code: int
+    msg: str
+
+    def __init__(self, **ctx: Any) -> None:
+        self.__dict__ = ctx
+
+    def __str__(self) -> str:
+        return self.msg.format(**self.__dict__)
 
 
-class CreateAskError(UpbitError):
-    def __str__(self):
-        return "주문 요청 정보가 올바르지 않습니다."
+class UpbitError(UpbitErrorMixin, Exception):
+    pass
 
 
-class CreateBidError(UpbitError):
-    def __str__(self):
-        return "주문 요청 정보가 올바르지 않습니다."
+class UpbitBadRequestError(UpbitErrorMixin, Exception):
+    pass
 
 
-class InsufficientFundsAsk(UpbitError):
-    def __str__(self):
-        return "매수/매도 가능 잔고가 부족합니다."
+class UpbitUnauthorizedError(UpbitErrorMixin, Exception):
+    pass
 
 
-class InsufficientFundsBid(UpbitError):
-    def __str__(self):
-        return "매수/매도 가능 잔고가 부족합니다."
+class UpbitLimitError(UpbitErrorMixin, Exception):
+    pass
 
 
-class UnderMinTotalAsk(UpbitError):
-    def __str__(self):
-        return "주문 요청 금액이 최소 주문 금액 미만입니다."
+class CreateAskError(UpbitBadRequestError):
+    name = "create_ask_error"
+    code = 400
+    msg = "주문 요청 정보가 올바르지 않습니다."
 
 
-class UnderMinTotalBid(UpbitError):
-    def __str__(self):
-        return "주문 요청 금액이 최소 주문 금액 미만입니다."
+class CreateBidError(UpbitBadRequestError):
+    name = "create_bid_error"
+    code = 400
+    msg = "주문 요청 정보가 올바르지 않습니다."
 
 
-class WidthdrawAddressNotRegisterd(UpbitError):
-    def __str__(self):
-        return "허용되지 않은 출금 주소입니다."
+class InsufficientFundsAsk(UpbitBadRequestError):
+    name = "insufficient_funds_ask"
+    code = 400
+    msg = "매수/매도 가능 잔고가 부족합니다."
 
 
-class ValidationError(UpbitError):
-    def __str__(self):
-        return "잘못된 API 요청입니다."
+class InsufficientFundsBid(UpbitBadRequestError):
+    name = "insufficient_funds_bid"
+    code = 400
+    msg = "매수/매도 가능 잔고가 부족합니다."
 
 
-class InvalidQueryPayload(UpbitError):
-    def __str__(self):
-        return "JWT 헤더의 페이로드가 올바르지 않습니다."
+class UnderMinTotalAsk(UpbitBadRequestError):
+    name = "under_min_total_ask"
+    code = 400
+    msg = "주문 요청 금액이 최소 주문 금액 미만입니다."
 
 
-class JwtVerification(UpbitError):
-    def __str__(self):
-        return "JWT 토큰 검증에 실패했습니다."
+class UnderMinTotalBid(UpbitBadRequestError):
+    name = "under_min_total_bid"
+    code = 400
+    msg = "주문 요청 금액이 최소 주문 금액 미만입니다."
 
 
-class ExpiredAccessKey(UpbitError):
-    def __str__(self):
-        return "API 키가 만료되었습니다."
+class WidthdrawAddressNotRegisterd(UpbitBadRequestError):
+    name = "withdraw_address_not_registerd"
+    code = 400
+    msg = "허용되지 않은 출금 주소입니다."
 
 
-class NonceUsed(UpbitError):
-    def __str__(self):
-        return "이미 요청한 nonce값이 다시 사용되었습니다."
+class ValidationError(UpbitBadRequestError):
+    name = "validation_error"
+    code = 400
+    msg = "잘못된 API 요청입니다."
 
 
-class NoAutorizationIP(UpbitError):
-    def __str__(self):
-        return "허용되지 않은 IP 주소입니다."
+class InvalidQueryPayload(UpbitUnauthorizedError):
+    name = "invalid_query_payload"
+    code = 401
+    msg = "JWT 헤더의 페이로드가 올바르지 않습니다."
 
 
-class OutOfScope(UpbitError):
-    def __str__(self):
-        return "허용되지 않은 기능입니다."
+class JwtVerification(UpbitUnauthorizedError):
+    name = "jwt_verification"
+    code = 401
+    msg = "JWT 토큰 검증에 실패했습니다."
 
 
-class TooManyRequests(UpbitError):
-    def __str__(self):
-        return "요청 수 제한을 초과했습니다."
+class ExpiredAccessKey(UpbitUnauthorizedError):
+    name = "expired_access_key"
+    code = 401
+    msg = "API 키가 만료되었습니다."
 
 
-class RemainingReqParsingError(UpbitError):
-    def __str__(self):
-        return "요청 수 제한 파싱에 실패했습니다."
+class NonceUsed(UpbitUnauthorizedError):
+    name = "nonce_used"
+    code = 401
+    msg = "이미 요청한 nonce값이 다시 사용되었습니다."
 
 
-class InValidAccessKey(UpbitError):
-    def __str__(self):
-        return "잘못된 엑세스 키입니다."
+class NoAutorizationIP(UpbitUnauthorizedError):
+    name = "no_authorization_i_p"
+    code = 401
+    msg = "허용되지 않은 IP 주소입니다."
 
 
-def raise_error(resp):
-    error = json.loads(resp.text).get('error')
-    message = error.get('message')
-    name = error.get('name')
+class OutOfScope(UpbitUnauthorizedError):
+    name = "out_of_scope"
+    code = 401
+    msg = "허용되지 않은 기능입니다."
+
+
+class TooManyRequests(UpbitLimitError):
+    name = ""
+    code = 429
+    msg = "요청 수 제한을 초과했습니다."
+
+
+class RemainingReqParsingError(UpbitLimitError):
+    name = ""
+    code = -1
+    msg = "요청 수 제한 파싱에 실패했습니다."
+
+
+class InValidAccessKey(UpbitUnauthorizedError):
+    name = ""
+    code = -1
+    msg = "잘못된 엑세스 키입니다."
+
+
+bad_requests = [eval(err) for err in __all__[:-1] if eval(err).code == 400]
+unauthorized = [eval(err) for err in __all__[:-1] if eval(err).code == 401]
+
+
+def raise_error(resp: Response) -> None:
+    error = resp.json().get("error")
+    message = error.get("message")
+    name = error.get("name")
     code = resp.status_code
 
-    print(code)
-    print(message)
-    print(name)
-
-    if code == 429:
-        raise TooManyRequests()
+    if code == 400:
+        for err in bad_requests:
+            if err.name == name:
+                raise err
     elif code == 401:
-        if name == "jwt_verification":
-            raise JwtVerification()
-        elif name == "invalid_access_key":
-            raise InValidAccessKey()
+        for err in unauthorized:
+            if err.name == name:
+                raise err
+    elif code == 429:
+        raise TooManyRequests
     else:
-        raise UpbitError()
+        raise UpbitError(name=name, code=code, msg=message)

--- a/pyupbit/errors.py
+++ b/pyupbit/errors.py
@@ -19,7 +19,7 @@ __all__ = [
     "TooManyRequests",
     "RemainingReqParsingError",
     "InValidAccessKey",
-    "raise_error",
+    "raise_error", # raise_error must be in place of last in this list
 ]
 
 

--- a/pyupbit/request_api.py
+++ b/pyupbit/request_api.py
@@ -7,7 +7,7 @@ HTTP_RESP_CODE_START = 200
 HTTP_RESP_CODE_END   = 400
 
 
-def _parse_remaining_req(remaining_req):
+def _parse_remaining_req(remaining_req: Optional[str]) -> Dict[str, Any]:
     """parse the request limit data of the Upbit API
 
     Args:
@@ -36,7 +36,7 @@ def _parse_remaining_req(remaining_req):
 
 
 def _call_public_api(
-    url, **params: Any
+    url: str, **params: Any
 ) -> Optional[Tuple[Any, Dict[str, Any]]]:
     """call get type api
 
@@ -57,7 +57,7 @@ def _call_public_api(
 
 
 def _send_post_request(
-    url,
+    url: str,
     headers: Optional[Dict[str, str]] = None,
     data: Optional[Dict[str, Any]] = None,
 ) -> Optional[Tuple[Any, Dict[str, Any]]]:
@@ -72,7 +72,7 @@ def _send_post_request(
 
 
 def _send_get_request(
-    url,
+    url: str,
     headers: Optional[Dict[str, str]] = None,
     data: Optional[Dict[str, Any]] = None,
 ) -> Optional[Tuple[Any, Dict[str, Any]]]:
@@ -87,7 +87,7 @@ def _send_get_request(
 
 
 def _send_delete_request(
-    url,
+    url: str,
     headers: Optional[Dict[str, str]] = None,
     data: Optional[Dict[str, Any]] = None,
 ) -> Optional[Tuple[Any, Dict[str, Any]]]:

--- a/pyupbit/request_api.py
+++ b/pyupbit/request_api.py
@@ -7,7 +7,7 @@ HTTP_RESP_CODE_START = 200
 HTTP_RESP_CODE_END   = 400
 
 
-def _parse_remaining_req(remaining_req: Optional[str]) -> Dict[str, Any]:
+def _parse_remaining_req(remaining_req: str) -> Dict[str, Any]:
     """parse the request limit data of the Upbit API
 
     Args:
@@ -17,9 +17,6 @@ def _parse_remaining_req(remaining_req: Optional[str]) -> Dict[str, Any]:
         dict: {'group': 'market', 'min': 573, 'sec': 2}
     """
     try:
-        if remaining_req is None:
-            raise RemainingReqParsingError
-
         pattern = re.compile(r"group=([a-z\-]+); min=([0-9]+); sec=([0-9]+)")
         matched = pattern.search(remaining_req)
         if matched is None:
@@ -48,7 +45,7 @@ def _call_public_api(
     """
     resp = requests.get(url, params=params)
     if HTTP_RESP_CODE_START <= resp.status_code < HTTP_RESP_CODE_END:
-        remaining_req = resp.headers.get("Remaining-Req")
+        remaining_req = resp.headers.get("Remaining-Req", "")
         limit = _parse_remaining_req(remaining_req)
         data = resp.json()
         return data, limit
@@ -63,7 +60,7 @@ def _send_post_request(
 ) -> Optional[Tuple[Any, Dict[str, Any]]]:
     resp = requests.post(url, headers=headers, data=data)
     if HTTP_RESP_CODE_START <= resp.status_code < HTTP_RESP_CODE_END:
-        remaining_req = resp.headers.get("Remaining-Req")
+        remaining_req = resp.headers.get("Remaining-Req", "")
         limit = _parse_remaining_req(remaining_req)
         contents = resp.json()
         return contents, limit
@@ -78,7 +75,7 @@ def _send_get_request(
 ) -> Optional[Tuple[Any, Dict[str, Any]]]:
     resp = requests.get(url, headers=headers, data=data)
     if HTTP_RESP_CODE_START <= resp.status_code < HTTP_RESP_CODE_END:
-        remaining_req = resp.headers.get("Remaining-Req")
+        remaining_req = resp.headers.get("Remaining-Req", "")
         limit = _parse_remaining_req(remaining_req)
         contents = resp.json()
         return contents, limit
@@ -93,7 +90,7 @@ def _send_delete_request(
 ) -> Optional[Tuple[Any, Dict[str, Any]]]:
     resp = requests.delete(url, headers=headers, data=data)
     if HTTP_RESP_CODE_START <= resp.status_code < HTTP_RESP_CODE_END:
-        remaining_req = resp.headers.get("Remaining-Req")
+        remaining_req = resp.headers.get("Remaining-Req", "")
         limit = _parse_remaining_req(remaining_req)
         contents = resp.json()
         return contents, limit

--- a/pyupbit/request_api.py
+++ b/pyupbit/request_api.py
@@ -1,10 +1,7 @@
 import re
 import requests
-import json
-from pyupbit.errors import (UpbitError, 
-                           TooManyRequests, 
-                           raise_error, 
-                           RemainingReqParsingError)
+from typing import Any, Tuple, Dict, Optional
+from .errors import raise_error, RemainingReqParsingError
 
 HTTP_RESP_CODE_START = 200
 HTTP_RESP_CODE_END   = 400
@@ -14,36 +11,44 @@ def _parse_remaining_req(remaining_req):
     """parse the request limit data of the Upbit API
 
     Args:
-        remaining_req (str): "group=market; min=573; sec=9" 
+        remaining_req (str): "group=market; min=573; sec=9"
 
     Returns:
         dict: {'group': 'market', 'min': 573, 'sec': 2}
     """
     try:
-        p = re.compile(r"group=([a-z\-]+); min=([0-9]+); sec=([0-9]+)")
-        m = p.search(remaining_req)
+        if remaining_req is None:
+            raise RemainingReqParsingError
+
+        pattern = re.compile(r"group=([a-z\-]+); min=([0-9]+); sec=([0-9]+)")
+        matched = pattern.search(remaining_req)
+        if matched is None:
+            raise RemainingReqParsingError
+
         ret = {
-            'group': m.group(1),
-            'min': int(m.group(2)),
-            'sec': int(m.group(3))
+            "group": matched.group(1),
+            "min": int(matched.group(2)),
+            "sec": int(matched.group(3)),
         }
         return ret
     except:
         raise RemainingReqParsingError
 
 
-def _call_public_api(url, **params):
+def _call_public_api(
+    url, **params: Any
+) -> Optional[Tuple[Any, Dict[str, Any]]]:
     """call get type api
 
     Args:
-        url (str): REST API url 
+        url (str): REST API url
 
     Returns:
-        tuple: (data, req_limit_info) 
+        tuple: (data, req_limit_info)
     """
     resp = requests.get(url, params=params)
     if HTTP_RESP_CODE_START <= resp.status_code < HTTP_RESP_CODE_END:
-        remaining_req = resp.headers.get('Remaining-Req')
+        remaining_req = resp.headers.get("Remaining-Req")
         limit = _parse_remaining_req(remaining_req)
         data = resp.json()
         return data, limit
@@ -51,48 +56,46 @@ def _call_public_api(url, **params):
         raise_error(resp)
 
 
-def _send_post_request(url, headers=None, data=None):
-    if isinstance(headers, dict):
-        headers["Accept"] = "application/json"
-        headers["Content-Type"] = "application/json"
-
-    if isinstance(data, dict):
-        data = json.dumps(data)
-
+def _send_post_request(
+    url,
+    headers: Optional[Dict[str, str]] = None,
+    data: Optional[Dict[str, Any]] = None,
+) -> Optional[Tuple[Any, Dict[str, Any]]]:
     resp = requests.post(url, headers=headers, data=data)
     if HTTP_RESP_CODE_START <= resp.status_code < HTTP_RESP_CODE_END:
-        remaining_req = resp.headers.get('Remaining-Req')
+        remaining_req = resp.headers.get("Remaining-Req")
         limit = _parse_remaining_req(remaining_req)
         contents = resp.json()
-        return contents,limit 
+        return contents, limit
     else:
         raise_error(resp)
 
 
-def _send_get_request(url, headers=None, data=None):
+def _send_get_request(
+    url,
+    headers: Optional[Dict[str, str]] = None,
+    data: Optional[Dict[str, Any]] = None,
+) -> Optional[Tuple[Any, Dict[str, Any]]]:
     resp = requests.get(url, headers=headers, data=data)
     if HTTP_RESP_CODE_START <= resp.status_code < HTTP_RESP_CODE_END:
-        remaining_req = resp.headers.get('Remaining-Req')
+        remaining_req = resp.headers.get("Remaining-Req")
         limit = _parse_remaining_req(remaining_req)
         contents = resp.json()
-        return contents, limit 
-    else: 
+        return contents, limit
+    else:
         raise_error(resp)
 
 
-def _send_delete_request(url, headers=None, data=None):
-    if isinstance(headers, dict):
-        headers["Accept"] = "application/json"
-        headers["Content-Type"] = "application/json"
-
-    if isinstance(data, dict):
-        data = json.dumps(data)
-
+def _send_delete_request(
+    url,
+    headers: Optional[Dict[str, str]] = None,
+    data: Optional[Dict[str, Any]] = None,
+) -> Optional[Tuple[Any, Dict[str, Any]]]:
     resp = requests.delete(url, headers=headers, data=data)
     if HTTP_RESP_CODE_START <= resp.status_code < HTTP_RESP_CODE_END:
-        remaining_req = resp.headers.get('Remaining-Req')
+        remaining_req = resp.headers.get("Remaining-Req")
         limit = _parse_remaining_req(remaining_req)
         contents = resp.json()
-        return contents,limit 
+        return contents, limit
     else:
         raise_error(resp)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,72 @@
+import pytest
+from unittest.mock import Mock
+from requests.models import Response
+from pyupbit.errors import *
+from pyupbit.errors import (
+    UpbitErrorMixin,
+    BAD_REQUESTS,
+    UNAUTHORIZED,
+    TOO_MANY_REQ,
+)
+
+bad_requests = [err.name for err in BAD_REQUESTS]
+unauthorized = [err.name for err in UNAUTHORIZED]
+too_many_req = [err.name for err in TOO_MANY_REQ]
+
+
+def test_raise_error_with_bad_requests():
+    responses = list()
+    for err_name in bad_requests:
+        mock = Mock(spec=Response)
+        mock.json.return_value = {
+            "error": {
+                "name": err_name,
+                "message": "test_bad_requests",
+            }
+        }
+        mock.status_code = 400
+        responses.append(mock)
+
+    for response in responses:
+        with pytest.raises(UpbitErrorMixin) as exc:
+            raise_error(response)
+
+        assert exc.value.name == response.json()["error"]["name"]
+        assert exc.value.code == response.status_code
+
+
+def test_raise_error_with_unauthorized():
+    responses = list()
+    for err_name in unauthorized:
+        mock = Mock(spec=Response)
+        mock.json.return_value = {
+            "error": {
+                "name": err_name,
+                "message": "test_bad_requests",
+            }
+        }
+        mock.status_code = 401
+        responses.append(mock)
+
+    for response in responses:
+        with pytest.raises(UpbitErrorMixin) as exc:
+            raise_error(response)
+
+        assert exc.value.name == response.json()["error"]["name"]
+        assert exc.value.code == response.status_code
+
+
+def test_raise_error_with_too_many_req():
+    responses = list()
+    for err_name in too_many_req:
+        mock = Mock(spec=Response)
+        mock.text = err_name
+        mock.status_code = 429
+        responses.append(mock)
+
+    for response in responses:
+        with pytest.raises(UpbitErrorMixin) as exc:
+            raise_error(response)
+
+        assert exc.value.name == response.text
+        assert exc.value.code == response.status_code

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -31,8 +31,10 @@ def test_raise_error_with_bad_requests():
         with pytest.raises(UpbitErrorMixin) as exc:
             raise_error(response)
 
-        assert exc.value.name == response.json()["error"]["name"]
+        error = response.json()["error"]
+        assert exc.value.name == error["name"]
         assert exc.value.code == response.status_code
+        assert exc.value.msg != error["message"]
 
 
 def test_raise_error_with_unauthorized():
@@ -42,7 +44,7 @@ def test_raise_error_with_unauthorized():
         mock.json.return_value = {
             "error": {
                 "name": err_name,
-                "message": "test_bad_requests",
+                "message": "test_unauthorized",
             }
         }
         mock.status_code = 401
@@ -52,8 +54,10 @@ def test_raise_error_with_unauthorized():
         with pytest.raises(UpbitErrorMixin) as exc:
             raise_error(response)
 
-        assert exc.value.name == response.json()["error"]["name"]
+        error = response.json()["error"]
+        assert exc.value.name == error["name"]
         assert exc.value.code == response.status_code
+        assert exc.value.msg != error["message"]
 
 
 def test_raise_error_with_too_many_req():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -68,5 +68,6 @@ def test_raise_error_with_too_many_req():
         with pytest.raises(UpbitErrorMixin) as exc:
             raise_error(response)
 
+        # too_many_request error doesn't use json response but text
         assert exc.value.name == response.text
         assert exc.value.code == response.status_code


### PR DESCRIPTION
## Description
- Error class의 확장성을 고려해 재구성
  - 기존 `errors.py`는 모든 에러를 포함하지 않고 있습니다. 변경된 코드는 Upbit 전체 에러에 대한 핸들링을 모두 포함하고 있습니다.
  - 기존 Error class들은 `raise_error` 메소드에 `name`별로 if 조건문이 모두 필요한 반면, 새로운 구조는 해당 Error 클래스 선언과 `__all__`, `status_code`관련 코드만 추가하도록 유도해 `raise_error` 내부 코드가 최소한으로 변경되도록 유도했습니다.
  - Reference: https://github.com/samuelcolvin/pydantic/blob/master/pydantic/errors.py
- `errors.py` test case 추가
  - 기존 혹은 새로 추가될 Error Class가 알맞은 `status_code`와 `name`으로 해당 에러를 `raise`시키는지 검사합니다.
- `request_api.py`에 `typing` 모듈 적용
  - typing을 적용하면 linting을 통해 생산성이 향상될 뿐만 아니라 좀 더 안정적인 코딩을 가능하게 만들어줍니다.
  - 전체 코드 적용전에 `request_api.py`를 선제적으로 적용해보았습니다.

## Related Issues
https://github.com/sharebook-kr/pyupbit/issues/64

