### PR TITLE
get_ohlcv 및 get_ohlcv_from 에서 timezone 수정으로 메소드 스펙 바뀌던 문제 원복

### DIFF
--- a/pyupbit/quotation_api.py
+++ b/pyupbit/quotation_api.py
@@ -91,7 +91,7 @@ def get_ohlcv(ticker="KRW-BTC", interval="day", count=200, to=None,
         elif isinstance(to, pd._libs.tslibs.timestamps.Timestamp):
             to = to.to_pydatetime()
 
-        #to = to.astimezone(datetime.timezone.utc)
+        to = to.astimezone(datetime.timezone.utc)
 
         dfs = []
         count = max(count, 1)
@@ -107,7 +107,6 @@ def get_ohlcv(ticker="KRW-BTC", interval="day", count=200, to=None,
             for x in contents:
                 dt = datetime.datetime.strptime(
                     x['candle_date_time_kst'], "%Y-%m-%dT%H:%M:%S")
-                #dt_list.append(dt.astimezone())
                 dt_list.append(dt)
 
             df = pd.DataFrame(contents,
@@ -154,7 +153,7 @@ def get_ohlcv_from(ticker="KRW-BTC", interval="day", fromDatetime=None,
             fromDatetime = pd.to_datetime(fromDatetime).to_pydatetime()
         elif isinstance(fromDatetime, pd._libs.tslibs.timestamps.Timestamp):
             fromDatetime = fromDatetime.to_pydatetime()
-        #fromDatetime = fromDatetime.astimezone(datetime.timezone.utc)
+        fromDatetime = fromDatetime.astimezone(datetime.timezone.utc)
 
         if to is None:
             to = datetime.datetime.now()
@@ -162,7 +161,7 @@ def get_ohlcv_from(ticker="KRW-BTC", interval="day", fromDatetime=None,
             to = pd.to_datetime(to).to_pydatetime()
         elif isinstance(to, pd._libs.tslibs.timestamps.Timestamp):
             to = to.to_pydatetime()
-        #to = to.astimezone(datetime.timezone.utc)
+        to = to.astimezone(datetime.timezone.utc)
 
         dfs = []
         while to > fromDatetime:
@@ -177,10 +176,9 @@ def get_ohlcv_from(ticker="KRW-BTC", interval="day", fromDatetime=None,
             for x in contents:
                 dt = datetime.datetime.strptime(
                     x['candle_date_time_kst'], "%Y-%m-%dT%H:%M:%S")
-                #dt_list.append(dt.astimezone())
-                dt_list.append(dt)
-            # set timezone for time comparison
-            # timezone will be removed before DataFrame returned
+                dt_list.append(dt.astimezone())
+                # set timezone for time comparison
+                # timezone will be removed before DataFrame returned
 
             df = pd.DataFrame(contents,
                               columns=[
@@ -198,8 +196,9 @@ def get_ohlcv_from(ticker="KRW-BTC", interval="day", fromDatetime=None,
 
             to = datetime.datetime.strptime(
                 contents[-1]['candle_date_time_utc'], "%Y-%m-%dT%H:%M:%S")
-            #to = to.replace(tzinfo=datetime.timezone.utc)
+            to = to.replace(tzinfo=datetime.timezone.utc)
             # to compare fromTs and to, set tzinfo
+            # timezone will be removed before DataFrame returned
 
             if to > fromDatetime:
                 time.sleep(period)
@@ -207,6 +206,8 @@ def get_ohlcv_from(ticker="KRW-BTC", interval="day", fromDatetime=None,
         df = pd.concat(dfs).sort_index()
         df = df[df.index >= fromDatetime]
         df.index = df.index.tz_localize(None)
+        # remove timezone, return DataFrame whose index has no timezone
+        #   like get_ohlcv method
         df = df.rename(columns={"opening_price": "open",
                                 "high_price": "high",
                                 "low_price": "low",


### PR DESCRIPTION
두 메소드 모두 timezone이 없는 index로 구성된 DataFrame 반환

관련: 이슈 #91 