### PR TITLE
withdraw_coin 함수가 작동하지 않는 문제 해결

### DIFF
--- a/pyupbit/exchange_api.py
+++ b/pyupbit/exchange_api.py
@@ -515,11 +515,17 @@ class Upbit:
         """
         try:
             url = "https://api.upbit.com/v1/withdraws/coin"
-            data = {"currency": currency,
-                    "amount": amount,
-                    "address": address,
-                    "secondary_address": secondary_address,
-                    "transaction_type": transaction_type}
+            if secondary_address = 'None':
+                data = {"currency": currency,
+                        "amount": amount,
+                        "address": address,
+                        "transaction_type": transaction_type}
+            else:
+                data = {"currency": currency,
+                        "amount": amount,
+                        "address": address,
+                        "secondary_address": secondary_address,
+                        "transaction_type": transaction_type}
             headers = self._request_headers(data)
             result = _send_post_request(url, headers=headers, data=data)
             if contain_req:


### PR DESCRIPTION
Secondary Address가 존재하지 않는 경우 withdraw_coin 함수가 작동하지 않는 현상을 해결함.