### PR TITLE
[done, cancel] 두가지 동시에 요청가능한 기능업데이트

### DIFF
--- a/pyupbit/exchange_api.py
+++ b/pyupbit/exchange_api.py
@@ -292,7 +292,7 @@ class Upbit:
 
                 url = "https://api.upbit.com/v1/orders"
                 data = {'market': ticker_or_uuid,
-                        'state': state,
+                        'states[]': state, #[done, cancel] 두가지 동시에 요청가능한 기능업데이트
                         'page': page,
                         'limit': limit,
                         'order_by': 'desc'


### PR DESCRIPTION
업비트 개발자 참고해서 한번에 두가지 요청을 받는 기능으로 업데이트 했습니다.
한번에 조회해야 날자별로 순서대로 조회됩니다.

기존에 사용하던데로 사용해도되고 리스트로 ["done", "cancel"] 이렇게 요청해도 됩니다.

https://docs.upbit.com/reference/%EC%A3%BC%EB%AC%B8-%EB%A6%AC%EC%8A%A4%ED%8A%B8-%EC%A1%B0%ED%9A%8C

시장가 매수 주문은 체결 후 주문 상태가 cancel, done 두 경우 모두 발생할 수 있습니다.
- 시장가로 체결이 일어난 후 주문 잔량이 발생하는 경우, 남은 잔량이 반환되며 cancel 처리됩니다. 대부분의 경우 소수점 아래 8자리까지 나누어 떨어지지 않는 미미한 금액이 주문 잔량으로 발생하게 됩니다.
- 만일 주문 잔량 없이 딱 맞아떨어지게 체결이 발생한 경우에는 주문 상태가 done이 됩니다.